### PR TITLE
Small fix to build_test so that layer writing error case is exercised

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -288,7 +288,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		context("when the layers directory cannot be written to", func() {
 			it.Before(func() {
-				Expect(os.Chmod(layersDir, 0000)).To(Succeed())
+				Expect(os.Chmod(layersDir, 4444)).To(Succeed())
 			})
 
 			it.After(func() {


### PR DESCRIPTION
Previously, the test hit the error case where getting existing layers fails.