### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.7"
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/tini"
   id = "paketo-buildpacks/tini"
-  name = "Paketo Tini Buildpack"
+  name = "Paketo Buildpack for Tini"
 
 [metadata]
   include-files = ["bin/build", "bin/detect", "bin/run", "buildpack.toml"]


### PR DESCRIPTION
Renames 'Paketo Tini Buildpack' to 'Paketo Buildpack for Tini'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
