### PR TITLE
Add new dependency update workflow to .syncignore

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,1 +1,2 @@
 CODEOWNERS
+workflows/update-dependencies-from-metadata.yml


### PR DESCRIPTION
Adds the [new update-dependencies-from-metadata.yml workflow](https://github.com/paketo-buildpacks/github-config/pull/537) to the .syncignore file. This is to prevent the new workflow from rolling out to the repository until the related dependency management code is added to the repository. The workflow can be removed from the .syncignore when maintainers are ready to move away from the old dep-server related workflow (update-dependencies.yml) and use the new system instead.